### PR TITLE
Wrapper has the same interface as the wrapped function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Version 0.2.99.9000
 
+* A memoised function now has the same interface as the original function
+  (#14, @krlmlr).
+
 # Version 0.2.1
 
 * Update to fix outstanding R CMD check issues.

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -88,11 +88,16 @@ memoise <- memoize <- function(f) {
     hash <- digest(list(...))
     
     if (cache$has_key(hash)) {
-      cache$get(hash)
+      res <- cache$get(hash)
     } else {
-      res <- f(...)
+      res <- withVisible(f(...))
       cache$set(hash, res)
-      res
+    }
+
+    if (res$visible) {
+      res$value
+    } else {
+      invisible(res$value)
     }
   }
   attr(memo_f, "memoised") <- TRUE

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -57,11 +57,16 @@
 #' N <- 4; memA(N)
 #' N2 <- 4; memA(N2)
 #'
-#' # memoise() doesn't know about default parameters.
-#' memB <- memoise(function(n, dummy="a") { runif(n) })
+#' # memoise() knows about default parameters.
+#' b <- function(n, dummy="a") { runif(n) }
+#' memB <- memoise(b)
 #' memB(2)
 #' memB(2, dummy="a")
-#' # It doesn't know about parameter relevance, either.
+#' # This works, because the interface of the memoised function is the same as
+#' # that of the original function.
+#' formals(b)
+#' formals(memB)
+#' # However, it doesn't know about parameter relevance.
 #' # Different call means different cacheing, no matter
 #' # that the outcome is the same.
 #' memB(2, dummy="b")

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -63,11 +63,16 @@ N <- 5; memA(N)
 N <- 4; memA(N)
 N2 <- 4; memA(N2)
 
-# memoise() doesn't know about default parameters.
-memB <- memoise(function(n, dummy="a") { runif(n) })
+# memoise() knows about default parameters.
+b <- function(n, dummy="a") { runif(n) }
+memB <- memoise(b)
 memB(2)
 memB(2, dummy="a")
-# It doesn't know about parameter relevance, either.
+# This works, because the interface of the memoised function is the same as
+# that of the original function.
+formals(b)
+formals(memB)
+# However, it doesn't know about parameter relevance.
 # Different call means different cacheing, no matter
 # that the outcome is the same.
 memB(2, dummy="b")

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -90,3 +90,11 @@ test_that("symbol collision", {
   expect_true(forget(cachem))
   expect_equal(cachem(), 5)
 })
+
+test_that("visibility", {
+  vis <- function() NULL
+  invis <- function() invisible()
+
+  expect_true(withVisible(memoise(vis)())$visible)
+  expect_false(withVisible(memoise(invis)())$visible)
+})

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -11,7 +11,7 @@ test_that("memoisation works", {
   expect_equal(fn(), 4)
   expect_equal(fnm(), 3)
 
-  forget(fnm)
+  expect_true(forget(fnm))
   expect_equal(fnm(), 5)
 
   expect_true(is.memoised(fnm))
@@ -32,4 +32,61 @@ test_that("memoisation depends on argument", {
   expect_equal(fnm(2), 5)
   expect_equal(fnm(1), 3)
   expect_equal(fn(2), 6)
+})
+
+test_that("interface of wrapper matches interface of memoised function", {
+  fn <- function(j) { i <<- i + 1; i }
+  i <- 0
+
+  expect_equal(formals(fn), formals(memoise(fn)))
+  expect_equal(formals(runif), formals(memoise(runif)))
+  expect_equal(formals(paste), formals(memoise(paste)))
+})
+
+test_that("dot arguments are used for hash", {
+  fn <- function(...) { i <<- i + 1; i }
+  i <- 0
+  fnm <- memoise(fn)
+
+  expect_equal(fn(1), 1)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(1, 2), 3)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(), 4)
+
+  expect_true(forget(fnm))
+
+  expect_equal(fnm(1), 5)
+  expect_equal(fnm(1, 2), 6)
+  expect_equal(fnm(), 7)
+})
+
+test_that("default arguments are used for hash", {
+  fn <- function(j = 1) { i <<- i + 1; i }
+  i <- 0
+  fnm <- memoise(fn)
+
+  expect_equal(fn(1), 1)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(), 2)
+  expect_equal(fnm(2), 3)
+  expect_equal(fnm(), 2)
+})
+
+test_that("symbol collision", {
+  cache <- function(j = 1) { i <<- i + 1; i }
+  i <- 0
+  cachem <- memoise(cache)
+
+  expect_equal(cache(), 1)
+  expect_equal(cache(), 2)
+  expect_equal(cachem(), 3)
+  expect_equal(cachem(), 3)
+  expect_equal(cache(), 4)
+  expect_equal(cachem(), 3)
+
+  expect_true(forget(cachem))
+  expect_equal(cachem(), 5)
 })


### PR DESCRIPTION
Also, the wrapped function is referred to by `memoised_function`, which is clearer than `f`.

Same as hadley#14.