### PR TITLE
Use old-style interface if f has not been defined yet

### DIFF
--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -123,4 +123,12 @@ test_that("old-style interface", {
 
   expect_equal(fm(), 1)
   expect_equal(fm(3), 3)
+  expect_true(withVisible(fm())$visible)
+})
+
+test_that("old-style interface with invisible result", {
+  expect_warning(fm <- memoise(f), "old-style")
+  f <- function(a = 1) invisible(a)
+
+  expect_false(withVisible(fm())$visible)
 })

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -114,3 +114,13 @@ test_that("visibility", {
   expect_true(withVisible(memoise(vis)())$visible)
   expect_false(withVisible(memoise(invis)())$visible)
 })
+
+test_that("old-style interface", {
+  expect_warning(fm <- memoise(f), "old-style")
+  f <- function(a = 1) a
+
+  expect_equal(formals(fm), formals(function(...) NULL))
+
+  expect_equal(fm(), 1)
+  expect_equal(fm(3), 3)
+})


### PR DESCRIPTION
- without evaluating f: restarting evaluation of promise didn't seem to
  work
- wordy warning without call. = FALSE - want to show source with the
  warning

Fixes #7.