### PR TITLE
create special environment for the returned function

### DIFF
--- a/R/memoise.r
+++ b/R/memoise.r
@@ -35,7 +35,6 @@
 #' @name memoise
 #' @title Memoise a function.
 #' @param f     Function of which to create a memoised copy.
-#' @param envir Environment of the returned function.
 #' @seealso \code{\link{forget}}, \code{\link{is.memoised}},
 #'     \url{http://en.wikipedia.org/wiki/Memoization}
 #' @aliases memoise memoize
@@ -87,18 +86,18 @@
 #' memA(2)
 #' memA <- memoise(a)
 #' memA(2)
-memoise <- memoize <- function(f, envir = parent.frame()) {
+memoise <- memoize <- function(f) {
   # We must not even try evaluating f -- once we start, there's no way back
   if (inherits(try(eval.parent(substitute(f)), silent = TRUE), "try-error")) {
     warning("Can't access f -- using old-style memoisation with dots interface. ",
             "Define the memoised function before memoising to avoid this warning.")
     memoise_old(f)
   } else {
-    memoise_new(f, envir)
+    memoise_new(f)
   }
 }
 
-memoise_new <- function(f, envir) {
+memoise_new <- function(f) {
   f_formals <- formals(f)
   f_formal_names <- names(f_formals)
   f_formal_name_list <- lapply(f_formal_names, as.name)
@@ -131,7 +130,7 @@ memoise_new <- function(f, envir) {
   formals(memo_f) <- f_formals
   attr(memo_f, "memoised") <- TRUE
 
-  cache_env <- new.env(parent = envir)
+  cache_env <- new.env(parent = baseenv())
   cache_env$cache <- cache
   cache_env$memoised_function <- f
   cache_env$digest <- digest

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -134,6 +134,7 @@ memoise_new <- function(f, envir) {
   cache_env <- new.env(parent = envir)
   cache_env$cache <- cache
   cache_env$memoised_function <- f
+  cache_env$digest <- digest
   environment(memo_f) <- cache_env
 
   return(memo_f)

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -111,22 +111,25 @@ memoise_new <- function(f) {
 
   cache <- new_cache()
 
-  memo_f <- eval(bquote(function(...) {
-    hash <- digest(.(list_call))
+  memo_f <- eval(
+    bquote(function(...) {
+      hash <- digest(.(list_call))
 
-    if (cache$has_key(hash)) {
-      res <- cache$get(hash)
-    } else {
-      res <- withVisible(.(init_call))
-      cache$set(hash, res)
-    }
+      if (cache$has_key(hash)) {
+        res <- cache$get(hash)
+      } else {
+        res <- withVisible(.(init_call))
+        cache$set(hash, res)
+      }
 
-    if (res$visible) {
-      res$value
-    } else {
-      invisible(res$value)
-    }
-  }))
+      if (res$visible) {
+        res$value
+      } else {
+        invisible(res$value)
+      }
+    },
+    as.environment(list(list_call = list_call, init_call = init_call)))
+  )
   formals(memo_f) <- f_formals
   attr(memo_f, "memoised") <- TRUE
 

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -5,10 +5,12 @@
 \alias{memoize}
 \title{Memoise a function.}
 \usage{
-memoise(f)
+memoise(f, envir = parent.frame())
 }
 \arguments{
 \item{f}{Function of which to create a memoised copy.}
+
+\item{envir}{Environment of the returned function.}
 }
 \description{
 \code{mf <- memoise(f)} creates \code{mf}, a memoised copy of

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -5,12 +5,10 @@
 \alias{memoize}
 \title{Memoise a function.}
 \usage{
-memoise(f, envir = parent.frame())
+memoise(f)
 }
 \arguments{
 \item{f}{Function of which to create a memoised copy.}
-
-\item{envir}{Environment of the returned function.}
 }
 \description{
 \code{mf <- memoise(f)} creates \code{mf}, a memoised copy of

--- a/revdep/summary.md
+++ b/revdep/summary.md
@@ -10,7 +10,7 @@
 |language |en_US:en                     |
 |collate  |en_US.UTF-8                  |
 |tz       |NA                           |
-|date     |2015-09-17                   |
+|date     |2015-09-19                   |
 
 ## Packages
 


### PR DESCRIPTION
- add `memoised_function`, `cache` and `digest` to that environment
- don't need explicit parent environment, can use baseenv()
- explicit environment also for evaluation of bquote(...)
- revdep check shows no new errors