### PR TITLE
Specify enclosing environment of returned function via argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@
 * A memoised function now has the same interface as the original function,
   if the original function is known when `memoise` is called. (Otherwise,
   the old behavior is invoked, with a warning.) (#14, @krlmlr)
-* The enclosing environment of the memoised function contains only the necessary
-  symbols (#14, @krlmlr).
+* The enclosing environment of the memoised function is specified explicitly,
+  defaults to `parent.frame()`.
 * `is.memoised` now checks if the argument is a function.
 * Testing infrastructure, full test coverage.
 

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -35,6 +35,7 @@
 #' @name memoise
 #' @title Memoise a function.
 #' @param f     Function of which to create a memoised copy.
+#' @param envir Environment of the returned function.
 #' @seealso \code{\link{forget}}, \code{\link{is.memoised}},
 #'     \url{http://en.wikipedia.org/wiki/Memoization}
 #' @aliases memoise memoize
@@ -86,18 +87,18 @@
 #' memA(2)
 #' memA <- memoise(a)
 #' memA(2)
-memoise <- memoize <- function(f) {
+memoise <- memoize <- function(f, envir = parent.frame()) {
   # We must not even try evaluating f -- once we start, there's no way back
   if (inherits(try(eval.parent(substitute(f)), silent = TRUE), "try-error")) {
     warning("Can't access f -- using old-style memoisation with dots interface. ",
             "Define the memoised function before memoising to avoid this warning.")
     memoise_old(f)
   } else {
-    memoise_new(f)
+    memoise_new(f, envir)
   }
 }
 
-memoise_new <- function(f) {
+memoise_new <- function(f, envir) {
   f_formals <- formals(f)
   f_formal_names <- names(f_formals)
   f_formal_name_list <- lapply(f_formal_names, as.name)
@@ -133,7 +134,7 @@ memoise_new <- function(f) {
   formals(memo_f) <- f_formals
   attr(memo_f, "memoised") <- TRUE
 
-  cache_env <- new.env(parent = baseenv())
+  cache_env <- new.env(parent = envir)
   cache_env$cache <- cache
   cache_env$memoised_function <- f
   cache_env$digest <- digest

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -5,10 +5,12 @@
 \alias{memoize}
 \title{Memoise a function.}
 \usage{
-memoise(f)
+memoise(f, envir = parent.frame())
 }
 \arguments{
 \item{f}{Function of which to create a memoised copy.}
+
+\item{envir}{Environment of the returned function.}
 }
 \description{
 \code{mf <- memoise(f)} creates \code{mf}, a memoised copy of

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -76,6 +76,21 @@ test_that("default arguments are used for hash", {
   expect_equal(fnm(), 2)
 })
 
+test_that("default arguments are evaluated correctly", {
+  expect_false(exists("g"))
+  g <- function() 1
+  fn <- function(j = g()) { i <<- i + 1; i }
+  i <- 0
+  fnm <- memoise(fn)
+
+  expect_equal(fn(1), 1)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(1), 2)
+  expect_equal(fnm(), 2)
+  expect_equal(fnm(2), 3)
+  expect_equal(fnm(), 2)
+})
+
 test_that("symbol collision", {
   cache <- function(j = 1) { i <<- i + 1; i }
   i <- 0


### PR DESCRIPTION
- Necessary if the argument list contains non-base symbols
- default: `parent.frame()`