### PR TITLE
Incorporate review notes

### DIFF
--- a/R/memoise.r
+++ b/R/memoise.r
@@ -105,11 +105,11 @@ memoise_new <- function(f, envir) {
   f_formal_name_list <- lapply(f_formal_names, as.name)
 
   # list(...)
-  list_call <- as.call(c(list(quote(list)), f_formal_name_list))
+  list_call <- make_call(quote(list), f_formal_name_list)
 
   # memoised_function(...)
   init_call_args <- setNames(f_formal_name_list, f_formal_names)
-  init_call <- as.call(c(quote(memoised_function), init_call_args))
+  init_call <- make_call(quote(memoised_function), init_call_args)
 
   cache <- new_cache()
 
@@ -142,6 +142,11 @@ memoise_new <- function(f, envir) {
   environment(memo_f) <- cache_env
 
   return(memo_f)
+}
+
+make_call <- function(name, args) {
+  stopifnot(is.name(name), is.list(args))
+  as.call(c(list(name), args))
 }
 
 memoise_old <- function(f) {

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -100,7 +100,7 @@ memoise <- memoize <- function(f, envir = parent.frame()) {
 
 #' @importFrom stats setNames
 memoise_new <- function(f, envir) {
-  f_formals <- formals(f)
+  f_formals <- formals(args(f))
   f_formal_names <- names(f_formals)
   f_formal_name_list <- lapply(f_formal_names, as.name)
 

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -135,11 +135,11 @@ memoise_new <- function(f, envir) {
   formals(memo_f) <- f_formals
   attr(memo_f, "memoised") <- TRUE
 
-  cache_env <- new.env(parent = envir)
-  cache_env$cache <- cache
-  cache_env$memoised_function <- f
-  cache_env$digest <- digest
-  environment(memo_f) <- cache_env
+  memo_f_env <- new.env(parent = envir)
+  memo_f_env$cache <- cache
+  memo_f_env$memoised_function <- f
+  memo_f_env$digest <- digest
+  environment(memo_f) <- memo_f_env
 
   return(memo_f)
 }

--- a/R/memoise.r
+++ b/R/memoise.r
@@ -105,11 +105,11 @@ memoise_new <- function(f, envir) {
   f_formal_name_list <- lapply(f_formal_names, as.name)
 
   # list(...)
-  list_call <- as.call(c(list(as.name("list")), f_formal_name_list))
+  list_call <- as.call(c(list(quote(list)), f_formal_name_list))
 
   # memoised_function(...)
   init_call_args <- setNames(f_formal_name_list, f_formal_names)
-  init_call <- as.call(c(as.name("memoised_function"), init_call_args))
+  init_call <- as.call(c(quote(memoised_function), init_call_args))
 
   cache <- new_cache()
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -9,4 +9,6 @@ There were no ERRORs, WARNINGs, or NOTEs.
 I have also run R CMD check on 9 downstream dependencies of memoise
 (https://github.com/hadley/memoise/blob/7597e250e87322a064cd97adeea36e5bad669f7d/revdep/summary.md). All packages that I could install passed except:
 
-* lubridate: example failed most likely due to localized system (LC_TIME=de_CH.UTF-8)
+* lubridate: example failed most likely due to localized system (LC_TIME=de_CH.UTF-8).
+  The lubridate maintainers are aware of the problem and a currently working
+  on a release to fix this (and other) problems.

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -3,7 +3,8 @@ context("memoise")
 test_that("memoisation works", {
   fn <- function() { i <<- i + 1; i }
   i <- 0
-  fnm <- memoise(fn)
+
+  expect_that(fnm <- memoise(fn), not(gives_warning()))
   expect_equal(fn(), 1)
   expect_equal(fn(), 2)
   expect_equal(fnm(), 3)
@@ -22,7 +23,8 @@ test_that("memoisation works", {
 test_that("memoisation depends on argument", {
   fn <- function(j) { i <<- i + 1; i }
   i <- 0
-  fnm <- memoise(fn)
+
+  expect_that(fnm <- memoise(fn), not(gives_warning()))
   expect_equal(fn(1), 1)
   expect_equal(fn(1), 2)
   expect_equal(fnm(1), 3)
@@ -47,8 +49,8 @@ test_that("interface of wrapper matches interface of memoised function", {
 test_that("dot arguments are used for hash", {
   fn <- function(...) { i <<- i + 1; i }
   i <- 0
-  fnm <- memoise(fn)
 
+  expect_that(fnm <- memoise(fn), not(gives_warning()))
   expect_equal(fn(1), 1)
   expect_equal(fnm(1), 2)
   expect_equal(fnm(1), 2)
@@ -66,8 +68,8 @@ test_that("dot arguments are used for hash", {
 test_that("default arguments are used for hash", {
   fn <- function(j = 1) { i <<- i + 1; i }
   i <- 0
-  fnm <- memoise(fn)
 
+  expect_that(fnm <- memoise(fn), not(gives_warning()))
   expect_equal(fn(1), 1)
   expect_equal(fnm(1), 2)
   expect_equal(fnm(1), 2)
@@ -81,8 +83,8 @@ test_that("default arguments are evaluated correctly", {
   g <- function() 1
   fn <- function(j = g()) { i <<- i + 1; i }
   i <- 0
-  fnm <- memoise(fn)
 
+  expect_that(fnm <- memoise(fn), not(gives_warning()))
   expect_equal(fn(1), 1)
   expect_equal(fnm(1), 2)
   expect_equal(fnm(1), 2)

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -149,3 +149,11 @@ test_that("old-style interface with invisible result", {
 
   expect_false(withVisible(fm())$visible)
 })
+
+test_that("can memoise anonymous function", {
+  expect_that(fm <- memoise(function(a = 1) a), not(gives_warning()))
+  expect_equal(names(formals(fm))[[1]], "a")
+  expect_equal(fm(1), 1)
+  expect_equal(fm(2), 2)
+  expect_equal(fm(1), 1)
+})

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -157,3 +157,11 @@ test_that("can memoise anonymous function", {
   expect_equal(fm(2), 2)
   expect_equal(fm(1), 1)
 })
+
+test_that("can memoise primitive", {
+  expect_that(fm <- memoise(`+`), not(gives_warning()))
+  expect_equal(names(formals(fm)), names(formals(args(`+`))))
+  expect_equal(fm(1, 2), 1 + 2)
+  expect_equal(fm(2, 3), 2 + 3)
+  expect_equal(fm(1, 2), 1 + 2)
+})


### PR DESCRIPTION
- explicitly test that no warnings are given
- explicitly test that anonymous function can be memoized
- support memoization of primitives
- as.name -> quote
- extract function make_call
- fix misnomer: cache_env -> memo_f_env
- update CRAN release note